### PR TITLE
Apparent logic error in set selection?

### DIFF
--- a/hardware.py
+++ b/hardware.py
@@ -77,7 +77,7 @@ def input_string(string_ascii):
         # use the sign on the modulo result to see if we are going left or right
         push_button((lambda x: (x < 0 and 'Left' or 'Right'))(times_to_press), PRESS, abs(times_to_press))
         push_button('Stop', PRESS, 1)  # advance to next letter
-        current_set = return_current_set(letter, current_set)
+        current_set = return_current_set(letter, wanted_set)
     push_button('Stop', HOLD, 1)  # finish entry
 
 


### PR DESCRIPTION
As far as I can tell, there is a logic bug in the `input_string()` set selection code, that was causing some track names to be garbled on my MZ-R37.

`return_current_set()` was being called with `current_set` as the active set, but because of the call to `enter_correct_set()` earlier, `current_set` may no longer be the active set - now `wanted_set` is. The phrase "Denis & Denis" reliably triggers this issue on my MZ-R37 - the '&' character and everything following it is garbled because it thought it was in the wrong set.

This PR fixes this issue on my player, but I do not have any other devices to test it with. If my understanding of the character-entry state machine is correct, I think it should apply to the others too.

(also, incidentally, I can confirm that with this change, gmdrec works well on the MZ-R37, so that can be added to the supported-devices list!)